### PR TITLE
GM-210 글과 유저ID로 관심 선택 유무 전달하기

### DIFF
--- a/src/main/java/com/gaaji/interest/applicationservice/InterestExistRetrieveService.java
+++ b/src/main/java/com/gaaji/interest/applicationservice/InterestExistRetrieveService.java
@@ -1,0 +1,21 @@
+package com.gaaji.interest.applicationservice;
+
+import com.gaaji.interest.domain.PostId;
+import com.gaaji.interest.domain.PostType;
+import com.gaaji.interest.domain.UserId;
+import com.gaaji.interest.repository.InterestRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class InterestExistRetrieveService {
+
+    private final InterestRepository interestRepository;
+
+    public boolean isExistInterest(String postId, String userId, PostType postType) {
+        return interestRepository.isExistInterest(PostId.of(postId), UserId.of(userId), postType);
+    }
+}

--- a/src/main/java/com/gaaji/interest/controller/InterestExistRetrieveController.java
+++ b/src/main/java/com/gaaji/interest/controller/InterestExistRetrieveController.java
@@ -1,0 +1,28 @@
+package com.gaaji.interest.controller;
+
+
+import com.gaaji.interest.applicationservice.InterestExistRetrieveService;
+import com.gaaji.interest.domain.PostType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+public class InterestExistRetrieveController {
+
+    private final InterestExistRetrieveService interestExistRetrieveService;
+
+    @GetMapping("/interest/post/{postId}/user/{userId}")
+    public ResponseEntity<Boolean> isExistInterest(@PathVariable("postId") String postId,
+            @PathVariable("userId") String userId, @RequestParam(name = "type")PostType postType){
+
+        boolean interest = interestExistRetrieveService.isExistInterest(postId, userId,
+                postType);
+        return ResponseEntity.ok(interest);
+    }
+
+}

--- a/src/main/java/com/gaaji/interest/repository/InterestRepository.java
+++ b/src/main/java/com/gaaji/interest/repository/InterestRepository.java
@@ -1,5 +1,6 @@
 package com.gaaji.interest.repository;
 
+import com.gaaji.interest.domain.PostType;
 import org.springframework.data.domain.PageRequest;
 import com.gaaji.interest.domain.Interest;
 import com.gaaji.interest.domain.PostId;
@@ -25,4 +26,5 @@ public interface InterestRepository {
 
 	List<Interest> findByUserId(UserId userId, PageRequest pageRequest);
 
+    boolean isExistInterest(PostId postId, UserId userId, PostType postType);
 }

--- a/src/main/java/com/gaaji/interest/repository/InterestRepositoryImpl.java
+++ b/src/main/java/com/gaaji/interest/repository/InterestRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.gaaji.interest.repository;
 
+import com.gaaji.interest.domain.PostType;
 import java.util.List;
 import java.util.Optional;
 
@@ -36,7 +37,12 @@ public class InterestRepositoryImpl implements InterestRepository{
 		return this.jpaInterestRepository.findByUserId(userId, pageRequest);
 	}
 
-    @Override
+	@Override
+	public boolean isExistInterest(PostId postId, UserId userId, PostType postType) {
+		return jpaInterestRepository.existsByPostIdAndUserIdAndAndPostType(postId, userId, postType);
+	}
+
+	@Override
     public Optional<Interest> findByPostId(PostId postId) {
         return jpaInterestRepository.findByPostId(postId);
     }

--- a/src/main/java/com/gaaji/interest/repository/JpaInterestRepository.java
+++ b/src/main/java/com/gaaji/interest/repository/JpaInterestRepository.java
@@ -1,5 +1,6 @@
 package com.gaaji.interest.repository;
 
+import com.gaaji.interest.domain.PostType;
 import java.util.List;
 import java.util.Optional;
 
@@ -20,6 +21,8 @@ public interface JpaInterestRepository extends JpaRepository<Interest, InterestI
 
 
     Optional<Interest> findByPostId(PostId postId);
+
+	boolean existsByPostIdAndUserIdAndAndPostType(PostId postId, UserId userId, PostType postType);
     
 
 }

--- a/src/test/java/com/gaaji/interest/applicationservice/InterestExistRetrieveServiceTest.java
+++ b/src/test/java/com/gaaji/interest/applicationservice/InterestExistRetrieveServiceTest.java
@@ -1,0 +1,50 @@
+package com.gaaji.interest.applicationservice;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.gaaji.interest.domain.Interest;
+import com.gaaji.interest.domain.InterestId;
+import com.gaaji.interest.domain.PostId;
+import com.gaaji.interest.domain.PostType;
+import com.gaaji.interest.domain.UserId;
+import com.gaaji.interest.impl.FakeInterestRepository;
+import com.gaaji.interest.repository.InterestRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class InterestExistRetrieveServiceTest {
+    
+    @Test
+    void 리턴_TRUE () throws Exception{
+        //given
+        Interest interest = Interest.of(InterestId.of("aaa"), UserId.of("bbb"), PostId.of("ccc"), PostType.USEDITEM);
+        InterestRepository interestRepository = new FakeInterestRepository();
+        InterestExistRetrieveService interestExistRetrieveService = new InterestExistRetrieveService(interestRepository);
+
+        interestRepository.save(interest);
+
+        //when
+        boolean existInterest = interestExistRetrieveService.isExistInterest("ccc", "bbb",
+                PostType.USEDITEM);
+        //then
+        assertThat(existInterest).isTrue();
+    }
+
+    @Test
+    void 리턴_FALSE () throws Exception{
+        //given
+        Interest interest = Interest.of(InterestId.of("aaa"), UserId.of("bbb"), PostId.of("asdasdasd"), PostType.USEDITEM);
+        InterestRepository interestRepository = new FakeInterestRepository();
+        InterestExistRetrieveService interestExistRetrieveService = new InterestExistRetrieveService(interestRepository);
+
+        interestRepository.save(interest);
+
+        //when
+        boolean existInterest = interestExistRetrieveService.isExistInterest("ccc", "bbb",
+                PostType.USEDITEM);
+        //then
+        assertThat(existInterest).isFalse();
+    }
+
+}

--- a/src/test/java/com/gaaji/interest/controller/InterestExistRetrieveControllerTest.java
+++ b/src/test/java/com/gaaji/interest/controller/InterestExistRetrieveControllerTest.java
@@ -1,0 +1,64 @@
+package com.gaaji.interest.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.gaaji.interest.applicationservice.InterestExistRetrieveService;
+import org.apache.http.HttpHeaders;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+@WebMvcTest(controllers = InterestExistRetrieveController.class)
+class InterestExistRetrieveControllerTest {
+    
+    @Autowired
+    MockMvc mockMvc;
+    
+    @MockBean
+    InterestExistRetrieveService interestExistRetrieveService;
+    
+    @InjectMocks
+    InterestExistRetrieveController interestExistRetrieveController;
+    
+    @Test
+    void 관심_조회_TRUE () throws Exception{
+        //given
+        given(interestExistRetrieveService.isExistInterest(anyString(), anyString(), any()))
+                .willReturn(true);
+        //when
+        mockMvc.perform(MockMvcRequestBuilders.get("/interest/post/asd/user/asdf?type=USEDITEM")
+                .header(HttpHeaders.AUTHORIZATION,"Bearer tokens"))
+                //then
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(content().string("true"))
+                .andDo(print());
+    }
+
+    @Test
+    void 관심_조회_FALSE () throws Exception{
+        //given
+        given(interestExistRetrieveService.isExistInterest(anyString(), anyString(), any()))
+                .willReturn(false);
+        //when
+        mockMvc.perform(MockMvcRequestBuilders.get("/interest/post/asd/user/asdf?type=USEDITEM")
+                        .header(HttpHeaders.AUTHORIZATION,"Bearer tokens"))
+                //then
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(content().string("false"))
+                .andDo(print());
+    }
+
+}

--- a/src/test/java/com/gaaji/interest/impl/FakeInterestRepository.java
+++ b/src/test/java/com/gaaji/interest/impl/FakeInterestRepository.java
@@ -3,6 +3,7 @@ package com.gaaji.interest.impl;
 import com.gaaji.interest.domain.Interest;
 import com.gaaji.interest.domain.InterestId;
 import com.gaaji.interest.domain.PostId;
+import com.gaaji.interest.domain.PostType;
 import com.gaaji.interest.domain.UserId;
 import com.gaaji.interest.repository.InterestRepository;
 import java.util.HashMap;
@@ -46,4 +47,12 @@ public class FakeInterestRepository implements InterestRepository {
 		// TODO Auto-generated method stub
 		return null;
 	}
+
+    @Override
+    public boolean isExistInterest(PostId postId, UserId userId, PostType postType) {
+        return storage.values().stream()
+                .filter(i -> PostId.of(i.getPostId()).equals(postId))
+                .filter(i -> UserId.of(i.getUserId()).equals(userId))
+                .anyMatch(i -> i.getPostType().equals(postType));
+    }
 }


### PR DESCRIPTION
# GM-210 글과 유저ID로 관심 선택 유무 전달하기
## Description
> 중고거래 글 내용을 조회 시에 내가 관심을 선택 했는지 안했는지에 대해 체크할 수 있는 내용을 조회한다.

## PR Type
- [ ] Hotfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor (code, package, etc.)
- [ ] Build (gradle, spring, etc) 
- [ ] Documentation content changes (api docs, etc.)
- [ ] Infra (cloud, security, etc.)
- [ ] Other... Please describe :

## Related Issues
- [중고]GM-209

## Issues

게시글 ID, 유저ID, 관심 타입을 통해 관심 선택 유무를 반환한다.


#### 관심 데이터 상태
![image](https://user-images.githubusercontent.com/76154390/217185369-115f827a-93f9-4843-96f9-d71d9a40d50d.png)

#### 있는 데이터의 경우
![image](https://user-images.githubusercontent.com/76154390/217185403-87182ea4-257e-4acb-aebd-1a49e5ce7ad2.png)

#### 없는 데이터의 경우
![image](https://user-images.githubusercontent.com/76154390/217185440-c08241c5-3763-4de9-b487-ef34594c69bc.png)


### Test
  
![image](https://user-images.githubusercontent.com/76154390/217185638-6f037274-e4b1-469f-a8bf-ea42e77b0d66.png)

*** 

## Think About..  

## Conclusion  
> 일 두번씩 하는ㄱ ㅓ개 귀찮다.
